### PR TITLE
fix_isObject_assertion

### DIFF
--- a/jsonUdf.cc
+++ b/jsonUdf.cc
@@ -68,7 +68,7 @@ StringVal JsonGetObject(FunctionContext *context, const StringVal & jsonVal, con
 #define selectValByToken(tok) { \
     RAPIDJSON_NAMESPACE::Value& va = *currentVal;  \
     RAPIDJSON_NAMESPACE::Value key(RAPIDJSON_NAMESPACE::StringRef(tok.c_str())); \
-    if (va.HasMember(key)) { \
+    if (va.IsObject() && va.HasMember(key)) { \
         currentVal = &(va[key]); \
     } else { \
         /* context->AddWarning("no member"); */ \


### PR DESCRIPTION
Test case: 

	Parsing a json like `{"project":"yes"}` with "$.project.yes.no"
        would case `isObject` assertion fail, throwing an exception,
	thus might break the impala cluster.
Fix:
	Add `isObject()` checking, which is a pre-condition before calling `HasMember(key)`